### PR TITLE
Support class constants for services' names

### DIFF
--- a/src/Rules/ContainerInterfacePrivateServiceRule.php
+++ b/src/Rules/ContainerInterfacePrivateServiceRule.php
@@ -33,17 +33,15 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		$services = $this->serviceMap->getServices();
-		return $node instanceof MethodCall
-			&& $node->name === 'get'
-			&& $scope->getType($node->var)->getClass() === ContainerInterface::class
-			&& isset($node->args[0])
-			&& $node->args[0] instanceof Arg
-			&& $node->args[0]->value instanceof String_
-			&& \array_key_exists($node->args[0]->value->value, $services)
-			&& !$services[$node->args[0]->value->value]['public']
-			? [\sprintf('Service "%s" is private.', $node->args[0]->value->value)]
-			: [];
+        if ($node instanceof MethodCall && $node->name === 'get' && $scope->getType($node->var)->getClass() === ContainerInterface::class) {
+            $service = $this->serviceMap->getServiceFromNode($node->args[0] ?? null);
+
+            if (!is_null($service) && !$service['public']) {
+                return [\sprintf('Service "%s" is private.', $service['id'])];
+            }
+        }
+
+        return [];
 	}
 
 }

--- a/src/Rules/ContainerInterfaceUnknownServiceRule.php
+++ b/src/Rules/ContainerInterfaceUnknownServiceRule.php
@@ -33,16 +33,15 @@ final class ContainerInterfaceUnknownServiceRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		$services = $this->serviceMap->getServices();
-		return $node instanceof MethodCall
-			&& $node->name === 'get'
-			&& $scope->getType($node->var)->getClass() === ContainerInterface::class
-			&& isset($node->args[0])
-			&& $node->args[0] instanceof Arg
-			&& $node->args[0]->value instanceof String_
-			&& !\array_key_exists($node->args[0]->value->value, $services)
-			? [\sprintf('Service "%s" is not registered in the container.', $node->args[0]->value->value)]
-			: [];
+		if ($node instanceof MethodCall && $node->name === 'get' && $scope->getType($node->var)->getClass() === ContainerInterface::class) {
+			$service = $this->serviceMap->getServiceFromNode($node->args[0] ?? null);
+
+			if (is_null($service)) {
+				return [\sprintf('Service "%s" is not registered in the container.', $node->args[0]->value->value ?? $node->args[0]->value->class)];
+			}
+		}
+
+		return [];
 	}
 
 }

--- a/src/Type/ContainerInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/ContainerInterfaceDynamicReturnTypeExtension.php
@@ -43,14 +43,12 @@ final class ContainerInterfaceDynamicReturnTypeExtension implements DynamicMetho
 		MethodCall $methodCall,
 		Scope $scope
 	): Type {
-		$services = $this->serviceMap->getServices();
-		return isset($methodCall->args[0])
-			&& $methodCall->args[0] instanceof Arg
-			&& $methodCall->args[0]->value instanceof String_
-			&& \array_key_exists($methodCall->args[0]->value->value, $services)
-			&& !$services[$methodCall->args[0]->value->value]['synthetic']
-			? new ObjectType($services[$methodCall->args[0]->value->value]['class'])
-			: $methodReflection->getReturnType();
+		$service = $this->serviceMap->getServiceFromNode($methodCall->args[0] ?? null);
+		if (is_null($service) || $service['synthetic']) {
+			return $methodReflection->getReturnType();
+		}
+
+		return new ObjectType($service['class'] ?? $service['id']);
 	}
 
 }

--- a/tests/ServiceMapTest.php
+++ b/tests/ServiceMapTest.php
@@ -14,46 +14,63 @@ final class ServiceMapTest extends TestCase
 
 	public function testGetServices()
 	{
-		$serviceMap = new ServiceMap(__DIR__ . '/container.xml');
+		$serviceMap = new ServiceMap(__DIR__.'/container.xml');
+
+		$servicesProperty = (new \ReflectionClass($serviceMap))->getProperty('services');
+		$servicesProperty->setAccessible(true);
+
 		self::assertEquals(
 			[
 				'withoutClass' => [
+					'id' => 'withoutClass',
 					'class' => \null,
 					'public' => \true,
 					'synthetic' => \false,
 				],
 				'withClass' => [
+					'id' => 'withClass',
 					'class' => 'Foo',
 					'public' => \true,
 					'synthetic' => \false,
 				],
+				'FullyQualified\Foo' => [
+					'id' => 'FullyQualified\Foo',
+					'class' => null,
+					'public' => \true,
+					'synthetic' => \false,
+				],
 				'withoutPublic' => [
+					'id' => 'withoutPublic',
 					'class' => 'Foo',
 					'public' => \true,
 					'synthetic' => \false,
 				],
 				'publicNotFalse' => [
+					'id' => 'publicNotFalse',
 					'class' => 'Foo',
 					'public' => \true,
 					'synthetic' => \false,
 				],
 				'private' => [
+					'id' => 'private',
 					'class' => 'Foo',
 					'public' => \false,
 					'synthetic' => \false,
 				],
 				'synthetic' => [
+					'id' => 'synthetic',
 					'class' => 'Foo',
 					'public' => \true,
 					'synthetic' => \true,
 				],
 				'alias' => [
+					'id' => 'alias',
 					'class' => 'Foo',
 					'public' => \true,
 					'synthetic' => \false,
 				],
 			],
-			$serviceMap->getServices()
+			$servicesProperty->getValue($serviceMap)
 		);
 	}
 

--- a/tests/Type/ContainerInterfaceDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/ContainerInterfaceDynamicReturnTypeExtensionTest.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace Lookyman\PHPStan\Symfony\Type;
 
 use Lookyman\PHPStan\Symfony\ServiceMap;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
@@ -27,13 +29,13 @@ final class ContainerInterfaceDynamicReturnTypeExtensionTest extends TestCase
 	{
 		self::assertInstanceOf(
 			DynamicMethodReturnTypeExtension::class,
-			new ContainerInterfaceDynamicReturnTypeExtension(new ServiceMap(__DIR__ . '/../container.xml'))
+			new ContainerInterfaceDynamicReturnTypeExtension(new ServiceMap(__DIR__.'/../container.xml'))
 		);
 	}
 
 	public function testGetClass()
 	{
-		$extension = new ContainerInterfaceDynamicReturnTypeExtension(new ServiceMap(__DIR__ . '/../container.xml'));
+		$extension = new ContainerInterfaceDynamicReturnTypeExtension(new ServiceMap(__DIR__.'/../container.xml'));
 		self::assertEquals(ContainerInterface::class, $extension::getClass());
 	}
 
@@ -45,7 +47,7 @@ final class ContainerInterfaceDynamicReturnTypeExtensionTest extends TestCase
 		$methodFoo = $this->createMock(MethodReflection::class);
 		$methodFoo->expects(self::once())->method('getName')->willReturn('foo');
 
-		$extension = new ContainerInterfaceDynamicReturnTypeExtension(new ServiceMap(__DIR__ . '/../container.xml'));
+		$extension = new ContainerInterfaceDynamicReturnTypeExtension(new ServiceMap(__DIR__.'/../container.xml'));
 		self::assertTrue($extension->isMethodSupported($methodGet));
 		self::assertFalse($extension->isMethodSupported($methodFoo));
 	}
@@ -55,7 +57,7 @@ final class ContainerInterfaceDynamicReturnTypeExtensionTest extends TestCase
 	 */
 	public function testGetTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Type $expectedType)
 	{
-		$extension = new ContainerInterfaceDynamicReturnTypeExtension(new ServiceMap(__DIR__ . '/../container.xml'));
+		$extension = new ContainerInterfaceDynamicReturnTypeExtension(new ServiceMap(__DIR__.'/../container.xml'));
 		$type = $extension->getTypeFromMethodCall(
 			$methodReflection,
 			$methodCall,
@@ -76,6 +78,11 @@ final class ContainerInterfaceDynamicReturnTypeExtensionTest extends TestCase
 				$this->createMock(MethodReflection::class),
 				new MethodCall($this->createMock(Expr::class), '', [new Arg(new String_('withClass'))]),
 				new ObjectType('Foo'),
+			],
+			'foundFromClassConst' => [
+				$this->createMock(MethodReflection::class),
+				new MethodCall($this->createMock(Expr::class), '', [new Arg(new ClassConstFetch(new FullyQualified('FullyQualified\Foo'), 'class'))]),
+				new ObjectType('FullyQualified\Foo'),
 			],
 			'notFound' => [
 				$methodReflectionNotFound,

--- a/tests/container.xml
+++ b/tests/container.xml
@@ -4,6 +4,7 @@
     <service></service><!-- without id -->
     <service id="withoutClass"></service>
     <service id="withClass" class="Foo"></service>
+    <service id="FullyQualified\Foo"></service>
     <service id="withoutPublic" class="Foo"></service>
     <service id="publicNotFalse" class="Foo" public="true"></service>
     <service id="private" class="Foo" public="false"></service>


### PR DESCRIPTION
Hi!

With the newest versions of Symfony, it has become a common practice to use fully qualified class names as services' ids.

So I added support for using class constants like `Foo::class` as argument to `get()`