### PR TITLE
catch php warning: XmlContainer 

### DIFF
--- a/src/Exception/XmlContainerNotExistsException.php
+++ b/src/Exception/XmlContainerNotExistsException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Lookyman\PHPStan\Symfony\Exception;
+
+final class XmlContainerNotExistsException extends \InvalidArgumentException
+{
+
+}

--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Lookyman\PHPStan\Symfony;
 
+use Lookyman\PHPStan\Symfony\Exception\XmlContainerNotExistsException;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Name;
@@ -21,7 +22,11 @@ final class ServiceMap
 	{
 		$this->services = $aliases = [];
 		/** @var \SimpleXMLElement $def */
-		foreach (\simplexml_load_file($containerXml)->services->service as $def) {
+		$xml = @\simplexml_load_file($containerXml);
+		if ($xml === false) {
+			throw new XmlContainerNotExistsException(\sprintf('Container %s not exists', $containerXml));
+		}
+		foreach ($xml->services->service as $def) {
 			$attrs = $def->attributes();
 			if (!isset($attrs->id)) {
 				continue;

--- a/tests/ServiceMapTest.php
+++ b/tests/ServiceMapTest.php
@@ -24,6 +24,14 @@ final class ServiceMapTest extends TestCase
 		self::assertEquals($service, $serviceMap->getServiceFromNode(new String_($service['id'])));
 	}
 
+	/**
+	 * @expectedException \Lookyman\PHPStan\Symfony\Exception\XmlContainerNotExistsException
+	 */
+	public function testFileNotExists()
+	{
+		new ServiceMap(__DIR__ . '/foo.xml');
+	}
+
 	public function getServiceFromNodeProvider(): array
 	{
 		return [


### PR DESCRIPTION
`simplexml_load_file(): I/O warning : failed to load external entity "/private/var/www/phpstan-symfony/tests/foo.xml"`

https://github.com/ShipMonk/shipmonk/pull/1668