### PR TITLE
Add support for symfony Controllers

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,7 @@
 includes:
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+	excludes_analyse:
+		- %rootDir%/../../../tests/*/data/*

--- a/src/Rules/ContainerInterfacePrivateServiceRule.php
+++ b/src/Rules/ContainerInterfacePrivateServiceRule.php
@@ -8,6 +8,7 @@ use Lookyman\PHPStan\Symfony\ServiceMap;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
@@ -34,8 +35,10 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 	{
 		if ($node instanceof MethodCall && $node->name === 'get') {
 			$type = $scope->getType($node->var);
-			if ($type instanceof ObjectType
-				&& \in_array($type->getClassName(), ['Symfony\Component\DependencyInjection\ContainerInterface', 'Symfony\Bundle\FrameworkBundle\Controller\Controller'], \true)
+			$baseController = new ObjectType('Symfony\Bundle\FrameworkBundle\Controller\Controller');
+			$isInstanceOfController = $type instanceof ThisType && $baseController->isSuperTypeOf($type)->yes();
+			$isContainerInterface = $type instanceof ObjectType && $type->getClassName() === 'Symfony\Component\DependencyInjection\ContainerInterface';
+			if (($isContainerInterface || $isInstanceOfController)
 				&& isset($node->args[0])
 				&& $node->args[0] instanceof Arg
 			) {

--- a/src/Rules/ContainerInterfaceUnknownServiceRule.php
+++ b/src/Rules/ContainerInterfaceUnknownServiceRule.php
@@ -8,6 +8,7 @@ use Lookyman\PHPStan\Symfony\ServiceMap;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
@@ -34,8 +35,10 @@ final class ContainerInterfaceUnknownServiceRule implements Rule
 	{
 		if ($node instanceof MethodCall && $node->name === 'get') {
 			$type = $scope->getType($node->var);
-			if ($type instanceof ObjectType
-				&& \in_array($type->getClassName(), ['Symfony\Component\DependencyInjection\ContainerInterface', 'Symfony\Bundle\FrameworkBundle\Controller\Controller'], \true)
+			$baseController = new ObjectType('Symfony\Bundle\FrameworkBundle\Controller\Controller');
+			$isInstanceOfController = $type instanceof ThisType && $baseController->isSuperTypeOf($type)->yes();
+			$isContainerInterface = $type instanceof ObjectType && $type->getClassName() === 'Symfony\Component\DependencyInjection\ContainerInterface';
+			if (($isInstanceOfController || $isContainerInterface)
 				&& isset($node->args[0])
 				&& $node->args[0] instanceof Arg
 			) {

--- a/src/Rules/ContainerInterfaceUnknownServiceRule.php
+++ b/src/Rules/ContainerInterfaceUnknownServiceRule.php
@@ -12,6 +12,7 @@ use PHPStan\Type\ThisType;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
 
 final class ContainerInterfaceUnknownServiceRule implements Rule
 {
@@ -41,6 +42,7 @@ final class ContainerInterfaceUnknownServiceRule implements Rule
 			if (($isInstanceOfController || $isContainerInterface)
 				&& isset($node->args[0])
 				&& $node->args[0] instanceof Arg
+				&& !$node->args[0]->value instanceof Variable
 			) {
 				$service = $this->serviceMap->getServiceFromNode($node->args[0]->value);
 				if ($service === \null) {

--- a/tests/Rules/ContainerInterfacePrivateServiceRuleTest.php
+++ b/tests/Rules/ContainerInterfacePrivateServiceRuleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Lookyman\PHPStan\Symfony\Rules;
+
+use Lookyman\PHPStan\Symfony\ServiceMap;
+use PHPStan\Rules\Rule;
+
+final class ContainerInterfacePrivateServiceRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		$serviceMap = new ServiceMap(__DIR__ . '/../container.xml');
+
+		return new ContainerInterfacePrivateServiceRule($serviceMap);
+	}
+
+	public function testGetPrivateService()
+	{
+		$this->analyse([__DIR__ . '/data/ExampleController.php'], [
+			[
+				'Service "private" is private.',
+				14,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/ContainerInterfacePrivateServiceRuleTest.php
+++ b/tests/Rules/ContainerInterfacePrivateServiceRuleTest.php
@@ -10,6 +10,11 @@ use PHPStan\Rules\Rule;
 final class ContainerInterfacePrivateServiceRuleTest extends \PHPStan\Testing\RuleTestCase
 {
 
+	protected function setUp()
+	{
+		include_once __DIR__ . '/data/Controller.php';
+	}
+
 	protected function getRule(): Rule
 	{
 		$serviceMap = new ServiceMap(__DIR__ . '/../container.xml');

--- a/tests/Rules/ContainerInterfaceUnknownServiceRuleTest.php
+++ b/tests/Rules/ContainerInterfaceUnknownServiceRuleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Lookyman\PHPStan\Symfony\Rules;
+
+use Lookyman\PHPStan\Symfony\ServiceMap;
+use PHPStan\Rules\Rule;
+
+final class ContainerInterfaceUnknownServiceRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		$serviceMap = new ServiceMap(__DIR__ . '/../container.xml');
+
+		return new ContainerInterfaceUnknownServiceRule($serviceMap);
+	}
+
+	public function testGetUnknownService()
+	{
+		$this->analyse([__DIR__ . '/data/ExampleController.php'], [
+			[
+				'Service "service.not.found" is not registered in the container.',
+				20,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/ContainerInterfaceUnknownServiceRuleTest.php
+++ b/tests/Rules/ContainerInterfaceUnknownServiceRuleTest.php
@@ -10,6 +10,11 @@ use PHPStan\Rules\Rule;
 final class ContainerInterfaceUnknownServiceRuleTest extends \PHPStan\Testing\RuleTestCase
 {
 
+	protected function setUp()
+	{
+		include_once __DIR__ . '/data/Controller.php';
+	}
+
 	protected function getRule(): Rule
 	{
 		$serviceMap = new ServiceMap(__DIR__ . '/../container.xml');

--- a/tests/Rules/data/Controller.php
+++ b/tests/Rules/data/Controller.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+abstract class Controller
+{
+
+}

--- a/tests/Rules/data/ExampleController.php
+++ b/tests/Rules/data/ExampleController.php
@@ -21,4 +21,10 @@ final class ExampleController extends Controller
 		$service->noMethod();
 	}
 
+	public function getVariableService(string $serviceKey)
+	{
+		$service = $this->get($serviceKey);
+		$service->noMethod();
+	}
+
 }

--- a/tests/Rules/data/ExampleController.php
+++ b/tests/Rules/data/ExampleController.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types = 1);
 
 namespace Lookyman\PHPStan\Symfony\Rules\data;
 
@@ -6,12 +8,19 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 include __DIR__ . '/Controller.php';
 
-class ExampleController extends Controller
+final class ExampleController extends Controller
 {
 
-    public function getPrivateServiceAction()
-    {
-        $service = $this->get('private');
-        $service->noMethod();
-    }
+	public function getPrivateServiceAction()
+	{
+		$service = $this->get('private');
+		$service->noMethod();
+	}
+
+	public function getUnknownService()
+	{
+		$service = $this->get('service.not.found');
+		$service->noMethod();
+	}
+
 }

--- a/tests/Rules/data/ExampleController.php
+++ b/tests/Rules/data/ExampleController.php
@@ -6,8 +6,6 @@ namespace Lookyman\PHPStan\Symfony\Rules\data;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
-include __DIR__ . '/Controller.php';
-
 final class ExampleController extends Controller
 {
 

--- a/tests/Rules/data/ExampleController.php
+++ b/tests/Rules/data/ExampleController.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Lookyman\PHPStan\Symfony\Rules\data;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+include __DIR__ . '/Controller.php';
+
+class ExampleController extends Controller
+{
+
+    public function getPrivateServiceAction()
+    {
+        $service = $this->get('private');
+        $service->noMethod();
+    }
+}


### PR DESCRIPTION
`getClassName` returned for example AccountController, not `Controller`. 

```
vendor/shipmonk-php-code-checker/vendor/bin/phpstan analyse -l 6 -c phpstan.neon src/Fulfillment/Bundle/AccountApiBundle/Controller/AccountController.php
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------ 
  Line   AccountController.php                                 
 ------ ------------------------------------------------------ 
  44     Service "foobar" is not registered in the container.  
  45     Call to an undefined method object::callNo().         
 ------ ------------------------------------------------------ 
```
cc https://github.com/ShipMonk/shipmonk/pull/1668