### PR TITLE
Fix of container xml path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ includes:
 	- vendor/lookyman/phpstan-symfony/extension.neon
 parameters:
 	symfony:
-		container_xml_path: %rootDir%/../../../var/cache/dev/srcDevDebugProjectContainer.xml
+		container_xml_path: %rootDir%/../../../var/cache/dev/appDevDebugProjectContainer.xml
 ```
 
 ## Limitations


### PR DESCRIPTION
A typo in the path for the container xml was in the readme. I fixed it to the correct naming of Symfony.